### PR TITLE
Added attribute to hide series from outside the chart itself

### DIFF
--- a/src/directives/highchart.js
+++ b/src/directives/highchart.js
@@ -2,35 +2,82 @@
 
 angular.module('chartsExample.directives',[])
 
-.directive('chart', function () {
-  return {
-    restrict: 'E',
-    template: '<div></div>',
-    transclude:true,
-    replace: true,
+.directive('chart', ['$filter',
+    function ($filter) {
+        return {
+            restrict: 'E',
+            template: '<div></div>',
+            transclude: true,
+            replace: true,
+            scope: {
+                value: '@',
+                hiddenSeries: '='
+            },
 
-    link: function (scope, element, attrs) {
-      var chartsDefaults = {
-        chart: {
-          renderTo: element[0],
-          type: attrs.type || null,
-          height: attrs.height || null,
-          width: attrs.width || null
+            link: function (scope, element, attrs) {
+                scope.chart = null;
+
+                // When the chart is redrawn we want to consolidate the visible items
+                // with the object scope.hiddenSeries
+                var redrawCallback = function (event) {
+                    var series = event.currentTarget.series;
+                    var hiddenItems = [];
+                    // Push all of the invisible items
+                    for (var s in series) {
+                        if (!series[s].visible) {
+                            hiddenItems.push(s);
+                        }
+                    };
+                    // If the new array is different than the old one, edit the scope variable
+                    if (!angular.equals(scope.hiddenSeries, hiddenItems)) {
+                        angular.copy(hiddenItems, scope.hiddenSeries);
+                        // Since the event is called outside of AngularJS, we have to apply the changes
+                        scope.$apply();
+                    }
+                };
+
+                var chartsDefaults = {
+                    chart: {
+                        renderTo: element[0],
+                        events: { redraw: redrawCallback },
+                        type: attrs.type || null,
+                        height: attrs.height || null,
+                        width: attrs.width || null
+                    }
+                };
+
+                var showHideSeries = function () {
+                    if (!scope.chart) return;
+                    // Loop through the chart series
+                    for (var s in scope.chart.series) {
+                        // Show or hide the series in scope.hiddenSeries
+                        var show = !($filter('filter')(scope.hiddenSeries, s).length);
+                        scope.chart.series[s].setVisible(show, false);
+                    }
+                    scope.chart.redraw();
+                };
+
+                // Update when charts data changes
+                scope.$watch(function () { return attrs.value; }, function (value) {
+                    if (!attrs.value) return;
+                    // We need deep copy in order to NOT override original chart object.
+                    // This allows us to override chart data member and still the keep
+                    // our original renderTo will be the same
+                    var deepCopy = true;
+                    var newSettings = {};
+                    $.extend(deepCopy, newSettings, chartsDefaults, JSON.parse(attrs.value));
+                    scope.chart = new Highcharts.Chart(newSettings);
+                    // Consolidate series
+                    showHideSeries();
+                });
+
+                // Hide or show some series when they change
+                scope.$watch('hiddenSeries', function (newValue, oldValue) {
+                    if (!scope.chart) return;
+                    showHideSeries();
+                });
+            }
         }
-      };
 
-        //Update when charts data changes
-        scope.$watch(function() { return attrs.value; }, function(value) {
-          if(!attrs.value) return;
-            // We need deep copy in order to NOT override original chart object.
-            // This allows us to override chart data member and still the keep
-            // our original renderTo will be the same
-            var deepCopy = true;
-            var newSettings = {};
-            $.extend(deepCopy, newSettings, chartsDefaults, JSON.parse(attrs.value));
-            var chart = new Highcharts.Chart(newSettings);
-        });
-      }
     }
-
-});
+]);


### PR DESCRIPTION
I have added the attribute `hidden-series`: it takes an array as input containing the indexes of the series to hide. It defaults to the empty array `[]`, but it can be edited in an external controller in order to hide some series programmaticaly.

For example, you can hide or show all of the series by simply setting all of the indexes in the array:

``` html
<chart value="{{lineChart}}" type="line" hidden-series="mHidden"></chart>
```

In the Controller:

``` javascript
'use strict';

angular.module('chartsExample.controllers',[]).controller('MainCtrl', ['$scope','$http', 
    function($scope,$http) {
        $http.get("charts/lineChart.json").success(function(data) {
                $scope.lineChart = data;
                // Shows all of the series
                $scope.mHidden = [];
        });

        // Hides all of the series
        $scope.hideAll = function() {
            for (var x in $scope.mSeries) {
                $scope.mHidden.push(x);
            }
        };
}]);

```

Of course, when you deselect a series from within the Highcharts chart, the array is automatically updated as well.
